### PR TITLE
actually use `neighbors_key` in `milo`

### DIFF
--- a/pertpy/tools/_milo.py
+++ b/pertpy/tools/_milo.py
@@ -123,7 +123,7 @@ class Milo:
                 raise
         else:
             try:
-                use_rep = adata.uns["neighbors"]["params"]["use_rep"]
+                use_rep = adata.uns[neighbors_key]["params"]["use_rep"]
             except KeyError:
                 logging.warning("Using X_pca as default embedding")
                 use_rep = "X_pca"


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

-   [x] Referenced issue is linked
-   [ ] If you've fixed a bug or added code that should be tested, add tests!

**Additional context**

It's not immediately clear to me why `def test_count_nhoods_missing_nhoods()` would not capture this
